### PR TITLE
Allow for newlines in logfmt fields

### DIFF
--- a/scanner_test.go
+++ b/scanner_test.go
@@ -30,6 +30,9 @@ func TestScannerSimple(t *testing.T) {
 		{`y=`, []T{{"y", ""}}},
 		{`y`, []T{{"y", ""}}},
 		{`y=f`, []T{{"y", "f"}}},
+		// test for input with escaped quotes and newlines
+		{`y="* This is a \"TEST\"
+* This is another \"TEST\""`, []T{{"y", "* This is a \"TEST\"\n* This is another \"TEST\""}}},
 	}
 
 	for _, test := range tests {

--- a/unquote.go
+++ b/unquote.go
@@ -128,10 +128,6 @@ func unquoteBytes(s []byte) (t []byte, ok bool) {
 				w += utf8.EncodeRune(b[w:], rr)
 			}
 
-		// Quote, control characters are invalid.
-		case c == '"', c < ' ':
-			return
-
 		// ASCII
 		case c < utf8.RuneSelf:
 			b[w] = c


### PR DESCRIPTION
I have log entries like:

```
level=info msg="* The error is \"TEST\"
* Another error \"TEST 2\""
```

But when `unquoteBytes()` I get the error: `error unquoting bytes ""`

This patch allows for newlines in logfmt fields where the `unquoteBytes()` is used